### PR TITLE
Enable audio testability through RTCPeerConnectionFactory

### DIFF
--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Private.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory+Private.h
@@ -9,6 +9,7 @@
  */
 
 #import "RTCPeerConnectionFactory.h"
+#import <AVFoundation/AVFoundation.h>
 
 #include "api/peer_connection_interface.h"
 #include "api/scoped_refptr.h"
@@ -18,13 +19,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RTC_OBJC_TYPE (RTCPeerConnectionFactory)
 ()
 
-    /**
-     * PeerConnectionFactoryInterface created and held by this
-     * RTCPeerConnectionFactory object. This is needed to pass to the underlying
-     * C++ APIs.
-     */
-    @property(nonatomic,
-              readonly) rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> nativeFactory;
+
+
+/**
+ * PeerConnectionFactoryInterface created and held by this
+ * RTCPeerConnectionFactory object. This is needed to pass to the underlying
+ * C++ APIs.
+ */
+@property(nonatomic,
+        readonly) rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> nativeFactory;
+
+@property(nonatomic,
+        readonly) rtc::scoped_refptr<webrtc::AudioDeviceModule> internalAudioDeviceModule;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
@@ -9,6 +9,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
 
 #import "RTCMacros.h"
 
@@ -91,6 +92,9 @@ RTC_OBJC_EXPORT
 /* Stop an active AecDump recording */
 - (void)stopAecDump;
 
+- (void)initializeAudioTesting;
+- (void)deliverRecordedDataWithNumFrames:(uint32_t)numFrames
+                            ioData:(AudioBufferList*)ioData;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -66,18 +66,18 @@
 }
 
 @synthesize nativeFactory = _nativeFactory;
-@synthesize internalAudioDeviceModule = _internalAudioDeviceModule;
+@synthesize internalAudioDeviceModule = _audioDeviceModule;
 
 - (void)initializeAudioTesting {
   #if defined(WEBRTC_IOS)
-  auto adm = _internalAudioDeviceModule.get();
+  auto adm = _audioDeviceModule.get();
   static_cast<webrtc::ios_adm::AudioDeviceModuleIOS *>(adm)->InitializeAudioTesting();
   #endif
 }
 - (void)deliverRecordedDataWithNumFrames:(uint32_t)numFrames
                             ioData:(AudioBufferList*)ioData {
   #if defined(WEBRTC_IOS)
-  auto adm = _internalAudioDeviceModule.get();
+  auto adm = _audioDeviceModule.get();
   static_cast<webrtc::ios_adm::AudioDeviceModuleIOS *>(adm)->DeliverRecordedData(numFrames, ioData);
   #endif
 }

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -66,6 +66,21 @@
 }
 
 @synthesize nativeFactory = _nativeFactory;
+@synthesize internalAudioDeviceModule = _internalAudioDeviceModule;
+
+- (void)initializeAudioTesting {
+  #if defined(WEBRTC_IOS)
+  auto adm = _internalAudioDeviceModule.get();
+  static_cast<webrtc::ios_adm::AudioDeviceModuleIOS *>(adm)->InitializeAudioTesting();
+  #endif
+}
+- (void)deliverRecordedDataWithNumFrames:(uint32_t)numFrames
+                            ioData:(AudioBufferList*)ioData {
+  #if defined(WEBRTC_IOS)
+  auto adm = _internalAudioDeviceModule.get();
+  static_cast<webrtc::ios_adm::AudioDeviceModuleIOS *>(adm)->DeliverRecordedData(numFrames, ioData);
+  #endif
+}
 
 - (rtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule {
 #if defined(WEBRTC_IOS)
@@ -175,6 +190,7 @@
     dependencies.worker_thread = _workerThread.get();
     dependencies.signaling_thread = _signalingThread.get();
     _nativeFactory = webrtc::CreateModularPeerConnectionFactory(std::move(dependencies));
+    _audioDeviceModule = nil;
     NSAssert(_nativeFactory, @"Failed to initialize PeerConnectionFactory!");
   }
   return self;
@@ -265,6 +281,7 @@
     dependencies.media_transport_factory = std::move(mediaTransportFactory);
 #endif
     _nativeFactory = webrtc::CreateModularPeerConnectionFactory(std::move(dependencies));
+    _audioDeviceModule = audioDeviceModule;
     NSAssert(_nativeFactory, @"Failed to initialize PeerConnectionFactory!");
   }
   return self;

--- a/sdk/objc/native/src/audio/audio_device_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_ios.h
@@ -166,6 +166,10 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
 
   bool IsInterrupted();
 
+  void InitializeAudioTesting();
+
+  void DeliverRecordedData(UInt32 num_frames,
+                           AudioBufferList* io_data) const;
  private:
   // Called by the relevant AudioSessionObserver methods on |thread_|.
   void HandleInterruptionBegin();

--- a/sdk/objc/native/src/audio/audio_device_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_ios.mm
@@ -1138,5 +1138,15 @@ void AudioDeviceIOS::AddAudioSourceSink(webrtc::AudioSourceSink* audioSink) {
   audioSink_ = audioSink;
 }
 
+void AudioDeviceIOS::InitializeAudioTesting() {
+  audio_unit_->InitializeAudioTesting();
+}
+
+void AudioDeviceIOS::DeliverRecordedData(UInt32 num_frames,
+                                            AudioBufferList* io_data) const {
+    rtc::ArrayView<int16_t> recorded_audio(reinterpret_cast<int16_t*>(io_data->mBuffers[0].mData), num_frames);
+    fine_audio_buffer_->DeliverRecordedData(recorded_audio, kFixedRecordDelayEstimate);
+}
+
 }  // namespace ios_adm
 }  // namespace webrtc

--- a/sdk/objc/native/src/audio/audio_device_module_ios.h
+++ b/sdk/objc/native/src/audio/audio_device_module_ios.h
@@ -128,6 +128,9 @@ class AudioDeviceModuleIOS : public AudioDeviceModule {
   int32_t EnableBuiltInNS(bool enable) override;
 
   int32_t GetPlayoutUnderrunCount() const override;
+  void InitializeAudioTesting() const;
+  void DeliverRecordedData(UInt32 num_frames,
+                           AudioBufferList* io_data) const;
 #if defined(WEBRTC_IOS)
   int GetPlayoutAudioParameters(AudioParameters* params) const override;
   int GetRecordAudioParameters(AudioParameters* params) const override;

--- a/sdk/objc/native/src/audio/audio_device_module_ios.mm
+++ b/sdk/objc/native/src/audio/audio_device_module_ios.mm
@@ -659,6 +659,14 @@ AudioDeviceModuleIOS::AudioDeviceModuleIOS(AudioSourceSink* audioSink)
     return ok;
   }
 
+  void AudioDeviceModuleIOS::InitializeAudioTesting() const {
+    audio_device_->InitializeAudioTesting();
+  }
+
+  void AudioDeviceModuleIOS::DeliverRecordedData(UInt32 num_frames,
+                                                AudioBufferList* io_data) const {
+    audio_device_->DeliverRecordedData(num_frames, io_data);
+  }
 #if defined(WEBRTC_IOS)
   int AudioDeviceModuleIOS::GetPlayoutAudioParameters(
       AudioParameters* params) const {

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.h
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.h
@@ -92,6 +92,10 @@ class VoiceProcessingAudioUnit {
                   UInt32 num_frames,
                   AudioBufferList* io_data);
 
+  void InitializeAudioTesting();
+  
+  static bool vpio_enabled;
+
  private:
   // The C API used to set callbacks requires static functions. When these are
   // called, they will invoke the relevant instance method by casting

--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
@@ -82,6 +82,7 @@ VoiceProcessingAudioUnit::~VoiceProcessingAudioUnit() {
   DisposeAudioUnit();
 }
 
+bool VoiceProcessingAudioUnit::vpio_enabled = true;
 const UInt32 VoiceProcessingAudioUnit::kBytesPerSample = 2;
 
 bool VoiceProcessingAudioUnit::Init() {
@@ -395,8 +396,13 @@ OSStatus VoiceProcessingAudioUnit::OnDeliverRecordedData(
     AudioBufferList* io_data) {
   VoiceProcessingAudioUnit* audio_unit =
       static_cast<VoiceProcessingAudioUnit*>(in_ref_con);
-  return audio_unit->NotifyDeliverRecordedData(flags, time_stamp, bus_number,
+  
+  if (VoiceProcessingAudioUnit::vpio_enabled) {
+    return audio_unit->NotifyDeliverRecordedData(flags, time_stamp, bus_number,
                                                num_frames, io_data);
+  } else { 
+    return noErr;
+  }
 }
 
 OSStatus VoiceProcessingAudioUnit::NotifyGetPlayoutData(
@@ -464,6 +470,11 @@ void VoiceProcessingAudioUnit::DisposeAudioUnit() {
     }
     vpio_unit_ = nullptr;
   }
+}
+
+void VoiceProcessingAudioUnit::InitializeAudioTesting() {
+  VoiceProcessingAudioUnit::vpio_enabled = false;
+  RTCLog(@"Initializing Audio Testing...Removing Audio Unit Input Callback.");
 }
 
 }  // namespace ios_adm

--- a/tools_webrtc/ios/build_ios_libs.py
+++ b/tools_webrtc/ios/build_ios_libs.py
@@ -59,7 +59,7 @@ def _ParseArgs():
            'If specified together with -c, deletes the dir.')
   parser.add_argument('-r', '--revision', type=int, default=0,
       help='Specifies a revision number to embed if building the framework.')
-  parser.add_argument('-e', '--bitcode', action='store_true', default=True,
+  parser.add_argument('-e', '--bitcode', action='store_true', default=False,
       help='Compile with bitcode.')
   parser.add_argument('--verbose', action='store_true', default=False,
       help='Debug logging.')


### PR DESCRIPTION
**This PR is based to `testing` branch.** Testing Branch will not be merged to `develop` and `master`, and will be kept separate to be used for testing purposes. 

This PR adds interfaces for testing audio. Specifically, it allows us to inject audio frames into WebRTC, which will be forwarded to remote peer. By accessing the `audio_device_ios` and `VoiceProcessingAudioUnit`, we can directly inject `AudioBufferList`.