### PR TITLE
Replace deprecated constant.

### DIFF
--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
@@ -60,7 +60,7 @@ static RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *gWebRTCConfiguration = nil;
     // nonmixable, hence activating the session will interrupt any other
     // audio sessions which are also nonmixable.
     _category = AVAudioSessionCategoryPlayAndRecord;
-    _categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth;
+    _categoryOptions = AVAudioSessionCategoryOptionAllowBluetoothHFP;
 
     // Specify mode for two-way voice communication (e.g. VoIP).
     _mode = AVAudioSessionModeVoiceChat;


### PR DESCRIPTION
Deprecated된 `AVAudioSessionCategoryOptionAllowBluetooth`를 `AVAudioSessionCategoryOptionAllowBluetoothHFP`로 교체.